### PR TITLE
Implement reset for R&S scopes in base class

### DIFF
--- a/ivi/rohdeschwarz/rohdeschwarzBaseScope.py
+++ b/ivi/rohdeschwarz/rohdeschwarzBaseScope.py
@@ -514,6 +514,11 @@ class rohdeschwarzBaseScope(scpi.common.IdnCommand, scpi.common.ErrorQuery, scpi
     def _utility_self_test(self):
         pass
 
+    def _utility_reset(self):
+        # Reset and wait for completion
+        self._ask("*RST; *OPC?")
+        self._clear()
+
     def _init_channels(self):
         try:
             super(rohdeschwarzBaseScope, self)._init_channels()


### PR DESCRIPTION
The RST command should be synchronized with OPC?
in order for RST to finish before continuing.