### PR TITLE
N6700 improvements

### DIFF
--- a/ivi/agilent/agilentN6700.py
+++ b/ivi/agilent/agilentN6700.py
@@ -921,10 +921,10 @@ class agilentN6700(scpi.dcpwr.Base, scpi.dcpwr.Trigger,
         if not self._driver_operation_simulate:
             self._write("initiate:immediate:acquire (@%s)" % (index + 1))
             # Wait until WTG_meas (bit 3) bit is set to know when the instrument is
-            # ready to receive a trigger after initiating, or maximum 10 times
+            # ready to receive a trigger after initiating, or maximum 30 times
             # to not block indefinitely
             wtg_meas_set = False
-            for loop_count in range(20):
+            for loop_count in range(30):
                 operation = int(self._ask("stat:oper? (@%s)" % (index+1)))
                 if (operation & 8) == 8:
                     wtg_meas_set = True
@@ -946,4 +946,17 @@ class agilentN6700(scpi.dcpwr.Base, scpi.dcpwr.Trigger,
     def _trigger_acquire_immediate(self):
         if not self._driver_operation_simulate:
             self._write("initiate:immediate:acquire (@1:%s)" % (self._output_count))
+            # Wait until WTG_meas (bit 3) bit is set to know when the instrument is
+            # ready to receive a trigger after initiating, or maximum 30 times
+            # to not block indefinitely
+            wtg_meas_set = False
+            for loop_count in range(30):
+                operation = [int(val) for val in self._ask("stat:oper? (@1:%s)" % (self._output_count)).split(',')]
+                if all([a == 8 for a in operation]):
+                    wtg_meas_set = True
+                    break;
+
+            if not wtg_meas_set:
+                print("WTG_meas bit not set in status register")
+
             self._write("trigger:acquire:immediate (@1:%s)" % (self._output_count))


### PR DESCRIPTION
Add immediate trigger for all channels in Keysight N6700 driver
    
    Also increase number of reads of status register to wait
    for WTG_meas bit to be set to know when the trigger system
    is ready

Improve elog support in Keysight N6700 driver
    
    - Align naming of trigger functions with the acquire names
    - Add support for setting the resolution of the time interval
      between digitized measurements, RES20 and RES40