### PR TITLE
Fix visa module deprecation warning

### DIFF
--- a/ivi/interface/pyvisa.py
+++ b/ivi/interface/pyvisa.py
@@ -29,7 +29,7 @@ import sys
 from distutils.version import StrictVersion
 
 try:
-    import visa
+    import pyvisa as visa
     try:
         # New style PyVISA
         visa_rm = visa.ResourceManager()


### PR DESCRIPTION
Fix the following warning:
visa.py:23: FutureWarning: The visa module provided by PyVISA is
being deprecated. You can replace `import visa` by
`import pyvisa as visa` to achieve the same effect.

The reason for the deprecation is the possible conflict with the visa
package provided by the https://github.com/visa-sdk/visa-python which
can result in hard to debug situations.