### PR TITLE
Make regexp strings "raw-strings"

### DIFF
--- a/ivi/interface/linuxgpib.py
+++ b/ivi/interface/linuxgpib.py
@@ -31,7 +31,7 @@ def parse_visa_resource_string(resource_string):
     # valid resource strings:
     # GPIB::10::INSTR
     # GPIB0::10::INSTR
-    m = re.match('^(?P<prefix>(?P<type>GPIB)\d*)(::(?P<arg1>[^\s:]+))(::(?P<suffix>INSTR))$',
+    m = re.match(r'^(?P<prefix>(?P<type>GPIB)\d*)(::(?P<arg1>[^\s:]+))(::(?P<suffix>INSTR))$',
             resource_string, re.I)
 
     if m is not None:

--- a/ivi/interface/pyserial.py
+++ b/ivi/interface/pyserial.py
@@ -37,7 +37,7 @@ def parse_visa_resource_string(resource_string):
     # ASRL::/dev/ttyUSB0::INSTR
     # ASRL::/dev/ttyUSB0,9600::INSTR
     # ASRL::/dev/ttyUSB0,9600,8n1::INSTR
-    m = re.match('^(?P<prefix>(?P<type>ASRL)\d*)(::(?P<arg1>[^\s:]+))?(::(?P<suffix>INSTR))$',
+    m = re.match(r'^(?P<prefix>(?P<type>ASRL)\d*)(::(?P<arg1>[^\s:]+))?(::(?P<suffix>INSTR))$',
             resource_string, re.I)
 
     if m is not None:

--- a/ivi/ivi.py
+++ b/ivi/ivi.py
@@ -1828,7 +1828,7 @@ class Driver(DriverOperation, DriverIdentity, DriverUtility):
             # ASRL::COM1,9600,8n1::INSTR
             # ASRL::/dev/ttyUSB0,9600::INSTR
             # ASRL::/dev/ttyUSB0,9600,8n1::INSTR
-            m = re.match('^(?P<prefix>(?P<type>TCPIP|USB|GPIB|ASRL)\d*)(::(?P<arg1>[^\s:]+))?(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<arg3>[^\s:]+))?(::(?P<arg4>[^\s:]+))?(::(?P<suffix>INSTR))$', resource, re.I)
+            m = re.match(r'^(?P<prefix>(?P<type>TCPIP|USB|GPIB|ASRL)\d*)(::(?P<arg1>[^\s:]+))?(::(?P<arg2>[^\s:]+(\[.+\])?))?(::(?P<arg3>[^\s:]+))?(::(?P<arg4>[^\s:]+))?(::(?P<suffix>INSTR))$', resource, re.I)
             if m is None:
                 if 'pyvisa' in globals():
                     # connect with PyVISA


### PR DESCRIPTION
Fixes:
* SyntaxWarning: invalid escape sequence '\d'
* SyntaxWarning: invalid escape sequence '\s'